### PR TITLE
fix scoping on ionAudioPlay directive

### DIFF
--- a/dist/ion-audio.js
+++ b/dist/ion-audio.js
@@ -336,9 +336,13 @@ angular.module('ionic-audio', ['ionic'])
         return {
             //scope: true,
             restrict: 'A',
-            require: '^^ionAudioControls',
-            link: function(scope, element, attrs, controller) {
+            require: ['^^ionAudioTrack', '^^ionAudioControls'],
+            link: function(scope, element, attrs, controllers) {
                 var isLoading, currentStatus = 0;
+                
+                scope.track = controllers[0].getTrack();
+                
+                var controller = controllers[1];
 
                 var init = function() {
                     isLoading = false;


### PR DESCRIPTION
Maybe I'm doing something wrong, but the Play/Pause button doesn't change from Pause back to Play once the track finishes. The `ionAudioPlay` directive has a scope watcher for `track.status`, however it doesn't seem to be in scope.

This grabs the track from the `ionAudioTrack` parent directive, and places it in it's own scope. [Just like how `ionAudioControls` already does](https://github.com/arielfaur/ionic-audio/blob/97e51e90e51a121c4a2b973b56d436c3403b788e/dist/ion-audio.js#L331).

_There might be a better way of doing this(?), but this change is working for me._