### PR TITLE
Add undefined current track guards to pause and play.

### DIFF
--- a/dist/ion-audio.js
+++ b/dist/ion-audio.js
@@ -114,6 +114,9 @@ angular.module('ionic-audio', ['ionic'])
         };
 
         var pause = function() {
+            if(!currentTrack) {
+                return;
+            }
             console.log('ionic-audio: pausing track '  + currentTrack.title);
 
             currentMedia.pause();
@@ -135,6 +138,9 @@ angular.module('ionic-audio', ['ionic'])
 
 
         var play = function(track) {
+            if(!currentTrack) {
+                return;
+            }
             currentTrack = track;
 
             console.log('ionic-audio: playing track ' + currentTrack.title);


### PR DESCRIPTION
There is no way to determine if there is currently a track loaded or not. Being able to call pause and play regardless is helpful if you want to make sure no audio is playing after an event occurs.