### PR TITLE
Two way binding of track enabled for 2.0.

### DIFF
--- a/dist/ionic-audio-track-component.ts
+++ b/dist/ionic-audio-track-component.ts
@@ -58,6 +58,9 @@ export class AudioTrackComponent {
   constructor(private _audioProvider: AudioProvider) {}
   
   ngOnInit() {
+     this.render();
+  }
+  render() {
     if (!(this.track instanceof WebAudioTrack) && !(this.track instanceof CordovaAudioTrack)) {
       this._audioTrack = this._audioProvider.create(this.track); 
     } else {
@@ -66,7 +69,7 @@ export class AudioTrackComponent {
     }
     
     // update input track parameter with track is so we pass it to WebAudioProvider if needed
-    this.track.id = this._audioTrack.id; 
+    this.track.id = this._audioTrack.id;
   }
   
   play() {    
@@ -151,6 +154,12 @@ export class AudioTrackComponent {
       if (this._isFinished) {
         this.onFinish.emit(this.track);       
       }
+    }
+  }
+  //two way biding enable with ioic-audio
+  ngOnChanges(change) {
+    if(change.track) {
+      this.render();
     }
   }
 }


### PR DESCRIPTION
currently we can play the audio-track loaded during the initialization of ionic-audio. Whenever the model changed ,it won't change the track inside ionic-audio. I have put an ngOnChanges to detect the track change, and accordingly the track played will also be changed.

Thanks