### PR TITLE
Remove deprecated argument from IonicAudioModule.forRoot in demo

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -25,9 +25,8 @@ export function myCustomAudioProviderFactory() {
   ],
   imports: [
     IonicModule.forRoot(MyApp),
-    IonicAudioModule.forRoot({ provide: AudioProvider, useFactory: audioProviderFactory }), 
-    // or use custom function above to force a specific provider
-    // { provide: AudioProvider, useFactory: myCustomAudioProviderFactory }
+    IonicAudioModule.forRoot(),
+    // or use custom function above as forRoot argument to force a specific provider
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { ContactPage } from '../pages/contact/contact';
 import { HomePage } from '../pages/home/home';
 import { TabsPage } from '../pages/tabs/tabs';
 
-import { IonicAudioModule, AudioProvider, WebAudioProvider, audioProviderFactory } from 'ionic-audio/dist';
+import { IonicAudioModule, AudioProvider, WebAudioProvider } from 'ionic-audio/dist';
 
 /**
  * Sample custom factory function to use with ionic-audio


### PR DESCRIPTION
After running the demo app the following Typescript error is thrown: 
Argument of type '{ provide: typeof AudioProvider; useFactory: any; }' is not assignable to parameter of type 'AudioProvider'. In the module definition the argument is of type AudioProvider, so I guess there have been changes and this is a leftover. I removed the arguments for the demo app.module definition to use the argument defaults instead (as it is seen in the installed npm package)