### PR TITLE
feat(Events): Add onLoaded and onError output events on audio-track component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+bower_components

--- a/dist/ionic-audio-cordova-track.ts
+++ b/dist/ionic-audio-cordova-track.ts
@@ -241,6 +241,8 @@ export class CordovaAudioTrack implements IAudioTrack {
    * @method destroy
    */
   destroy() {
+    this.isLoaded = false;
+    this._hasLoaded = false;
     this.audio.release();  
     console.log(`Released track ${this.src}`);
   }

--- a/dist/ionic-audio-cordova-track.ts
+++ b/dist/ionic-audio-cordova-track.ts
@@ -17,6 +17,7 @@ export class CordovaAudioTrack implements IAudioTrack {
   public isPlaying: boolean = false;
   public isFinished: boolean = false;
   public isLoaded: boolean = false;
+  public hasError: boolean = false;
   private _progress: number = 0;
   private _completed: number = 0;
   private _duration: number;
@@ -38,27 +39,32 @@ export class CordovaAudioTrack implements IAudioTrack {
     this.audio = new Media(this.src, () => {
        console.log('Finished playback');
        this.stopTimer();
-       this.isFinished = true;  
+       this.isFinished = true;
        this.destroy();  // TODO add parameter to control whether to release audio on stop or finished
     }, (err) => {
-      console.log(`Audio error => track ${this.src}`, err);   
+      console.log(`Audio error => track ${this.src}`, err);
+      this.hasError = true;
     }, (status) => {
       switch (status) {
         case Media.MEDIA_STARTING:
           console.log(`Loaded track ${this.src}`);
           this._hasLoaded = true;
           this.isLoaded = true;
+          this.hasError = false;
           break;
         case Media.MEDIA_RUNNING:
           console.log(`Playing track ${this.src}`);
           this.isPlaying = true;
-          this._isLoading = false;          
+          this._isLoading = false;
+          this.hasError = false;
           break; 
         case Media.MEDIA_PAUSED:
           this.isPlaying = false;
-          break
+          this.hasError = false;
+          break;
         case Media.MEDIA_STOPPED:
           this.isPlaying = false;
+          this.hasError = false;
           break;
       }
     });  
@@ -241,6 +247,7 @@ export class CordovaAudioTrack implements IAudioTrack {
    * @method destroy
    */
   destroy() {
+    this.hasError = false;
     this.isLoaded = false;
     this._hasLoaded = false;
     this.audio.release();  

--- a/dist/ionic-audio-cordova-track.ts
+++ b/dist/ionic-audio-cordova-track.ts
@@ -16,6 +16,7 @@ export class CordovaAudioTrack implements IAudioTrack {
   private audio: any;
   public isPlaying: boolean = false;
   public isFinished: boolean = false;
+  public isLoaded: boolean = false;
   private _progress: number = 0;
   private _completed: number = 0;
   private _duration: number;
@@ -46,6 +47,7 @@ export class CordovaAudioTrack implements IAudioTrack {
         case Media.MEDIA_STARTING:
           console.log(`Loaded track ${this.src}`);
           this._hasLoaded = true;
+          this.isLoaded = true;
           break;
         case Media.MEDIA_RUNNING:
           console.log(`Playing track ${this.src}`);

--- a/dist/ionic-audio-interfaces.ts
+++ b/dist/ionic-audio-interfaces.ts
@@ -45,12 +45,12 @@ export interface IAudioTrack extends ITrackConstraint {
   isLoading: boolean;
   isFinished: boolean;
   isLoaded: boolean;
+  hasError: boolean;
   duration: number;
   progress: number;
   completed: number;
   canPlay:  boolean;
   error: MediaError;
-  
   play();
   pause();
   stop();

--- a/dist/ionic-audio-interfaces.ts
+++ b/dist/ionic-audio-interfaces.ts
@@ -44,6 +44,7 @@ export interface IAudioTrack extends ITrackConstraint {
   isPlaying: boolean; 
   isLoading: boolean;
   isFinished: boolean;
+  isLoaded: boolean;
   duration: number;
   progress: number;
   completed: number;

--- a/dist/ionic-audio-track-component.ts
+++ b/dist/ionic-audio-track-component.ts
@@ -63,6 +63,16 @@ export class AudioTrackComponent implements DoCheck {
 
   private _isLoaded: boolean = false;
 
+  /**
+   * Output property expects an event handler to be notified whenever playback has detected an error
+   *
+   * @property onLoaded
+   * @type {EventEmitter}
+   */
+  @Output() onError: EventEmitter <Error> = new EventEmitter();
+
+  private _hasError: boolean = false;
+
   private _audioTrack: IAudioTrack;
   
   constructor(private _audioProvider: AudioProvider) {}
@@ -179,6 +189,12 @@ export class AudioTrackComponent implements DoCheck {
       this._isLoaded = this._audioTrack.isLoaded;
       if (this._isLoaded) {
         this.onLoaded.emit(this.track);
+      }
+    }
+    if(!Object.is(this._audioTrack.hasError, this._hasError)) {
+      this._hasError = this._audioTrack.hasError;
+      if (this._hasError) {
+        this.onError.emit(new Error('Error when reading audio'));
       }
     }
   }

--- a/dist/ionic-audio-track-component.ts
+++ b/dist/ionic-audio-track-component.ts
@@ -52,6 +52,17 @@ export class AudioTrackComponent implements DoCheck {
   @Output() onFinish = new EventEmitter<ITrackConstraint>();
   
   private _isFinished: boolean = false;
+
+  /**
+   * Output property expects an event handler to be notified whenever playback has loaded
+   *
+   * @property onLoaded
+   * @type {EventEmitter}
+   */
+  @Output() onLoaded: EventEmitter <ITrackConstraint> = new EventEmitter();
+
+  private _isLoaded: boolean = false;
+
   private _audioTrack: IAudioTrack;
   
   constructor(private _audioProvider: AudioProvider) {}
@@ -149,6 +160,12 @@ export class AudioTrackComponent implements DoCheck {
       // track has stopped, trigger finish event
       if (this._isFinished) {
         this.onFinish.emit(this.track);       
+      }
+    }
+    if(!Object.is(this._audioTrack.isLoaded, this._isLoaded)) {
+      this._isLoaded = this._audioTrack.isLoaded;
+      if (this._isLoaded) {
+        this.onLoaded.emit(this.track);
       }
     }
   }

--- a/dist/ionic-audio-track-component.ts
+++ b/dist/ionic-audio-track-component.ts
@@ -83,18 +83,31 @@ export class AudioTrackComponent implements DoCheck {
     this._audioTrack.play();
     this._audioProvider.current = this._audioTrack.id;
   }
-  
+
   pause() {
     this._audioTrack.pause();
     this._audioProvider.current = undefined;
   }
-  
+
+  stop() {
+    this._audioTrack.stop();
+    this._audioProvider.current = undefined;
+  }
+
   toggle() {
     if (this._audioTrack.isPlaying) {
       this.pause();
     } else {
       this.play();
-    }  
+    }
+  }
+
+  toggleStop() {
+    if (this._audioTrack.isPlaying) {
+      this.stop();
+    } else {
+      this.play();
+    }
   }
   
   seekTo(time:number) {

--- a/dist/ionic-audio-track-play-component.ts
+++ b/dist/ionic-audio-track-play-component.ts
@@ -38,12 +38,11 @@ import {Component, ElementRef, Input} from '@angular/core';
 @Component({
     selector: 'audio-track-play',
     template: `
-    <button ion-button icon-only clear (click)="toggle($event)" [disabled]="audioTrack.error || audioTrack.isLoading">
-      <ion-icon name="pause" *ngIf="audioTrack.isPlaying && !audioTrack.isLoading"></ion-icon>
-      <ion-icon name="play" *ngIf="!audioTrack.isPlaying && !audioTrack.isLoading"></ion-icon>
-      <ng-content *ngIf="audioTrack.isLoading && !audioTrack.error"></ng-content>
-    </button>
-    `
+    <button class="btn-play-pause" ion-button round icon-only color="secondary" (click)="toggleStop()">
+        <ion-icon name="pause" *ngIf="audioTrack.isPlaying && !audioTrack.isLoading"></ion-icon>
+        <ion-icon name="play" *ngIf="!audioTrack.isPlaying && !audioTrack.isLoading"></ion-icon>
+        <ng-content *ngIf="audioTrack.isLoading && !audioTrack.error"></ng-content>
+    </button>`
 })
 export class AudioTrackPlayComponent {
   
@@ -78,12 +77,20 @@ export class AudioTrackPlayComponent {
   }
   
   constructor(private el: ElementRef) {}
-  
-  toggle(event: Event){    
+
+  toggle(event: Event){
     if (this.audioTrack.isPlaying) {
       this.audioTrack.pause()
     } else {
       this.audioTrack.play()
-    } 
+    }
+  }
+
+  toggleStop(event: Event){
+    if (this.audioTrack.isPlaying) {
+        this.audioTrack.stop();
+    } else {
+      this.audioTrack.play();
+    }
   }
 }

--- a/dist/ionic-audio-web-track.ts
+++ b/dist/ionic-audio-web-track.ts
@@ -247,6 +247,8 @@ export class WebAudioTrack implements IAudioTrack {
    * @method destroy
    */
   destroy() {
+    this.isLoaded = false;
+    this._hasLoaded = false;
     this.audio = undefined;  
     console.log(`Released track ${this.src}`);
   }

--- a/dist/ionic-audio-web-track.ts
+++ b/dist/ionic-audio-web-track.ts
@@ -18,6 +18,7 @@ export class WebAudioTrack implements IAudioTrack {
   public isPlaying: boolean = false;
   public isFinished: boolean = false;
   public isLoaded: boolean = false;
+  public hasError: boolean = false;
   private _progress: number = 0;
   private _completed: number = 0;
   private _duration: number;
@@ -44,6 +45,7 @@ export class WebAudioTrack implements IAudioTrack {
     this.audio.addEventListener("error", (err) => {
       console.log(`Audio error => track ${this.src}`, err);
       this.isPlaying = false;
+      this.hasError = true;
     }, false);
     
     this.audio.addEventListener("canplay", () => {
@@ -51,17 +53,20 @@ export class WebAudioTrack implements IAudioTrack {
       this._isLoading = false;
       this.isLoaded = true;
       this._hasLoaded = true;
+      this.hasError = false;
     }, false);
     
     this.audio.addEventListener("playing", () => {
       console.log(`Playing track ${this.src}`);
       this.isFinished = false;
       this.isPlaying = true;
+      this.hasError = false;
     }, false);
     
     this.audio.addEventListener("ended", () => {
       this.isPlaying = false;
       this.isFinished = true;
+      this.hasError = false;
       console.log('Finished playback');
     }, false);
     
@@ -249,6 +254,7 @@ export class WebAudioTrack implements IAudioTrack {
   destroy() {
     this.isLoaded = false;
     this._hasLoaded = false;
+    this.hasError = false;
     this.audio = undefined;  
     console.log(`Released track ${this.src}`);
   }

--- a/dist/ionic-audio-web-track.ts
+++ b/dist/ionic-audio-web-track.ts
@@ -17,6 +17,7 @@ export class WebAudioTrack implements IAudioTrack {
   private audio: HTMLAudioElement;
   public isPlaying: boolean = false;
   public isFinished: boolean = false;
+  public isLoaded: boolean = false;
   private _progress: number = 0;
   private _completed: number = 0;
   private _duration: number;
@@ -48,6 +49,7 @@ export class WebAudioTrack implements IAudioTrack {
     this.audio.addEventListener("canplay", () => {
       console.log(`Loaded track ${this.src}`);
       this._isLoading = false;
+      this.isLoaded = true;
       this._hasLoaded = true;
     }, false);
     

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "scripts": {
+    "watch": "nodemon -e ts -x \"npm run build\"",
+    "build": "node_modules/.bin/tsc -p ./",
     "prepublish": "tsc -p ./",
     "release": "npm run prepublish && npm publish",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Based on the onFinish event, it works on the same way. 
I needed to do something like that:

```
    <audio-track #audio *ngIf="myOnlyTrack" [track]="myOnlyTrack" (onLoaded)="onTrackLoaded($event)">
        <ion-item>
            <ion-thumbnail item-left>
                <audio-track-play dark [audioTrack]="audio"><ion-spinner></ion-spinner></audio-track-play>
            </ion-thumbnail>
        </ion-item>
    </audio-track>
```