### PR TITLE
Fix for issue #121

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,10 @@
     "release": "npm run prepublish && npm publish",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
+  "dependencies": {},
+  "devDependencies": {
+    "@angular/common": "4.0.0",
+    "@angular/core": "4.0.0",
     "@angular/compiler": "4.0.0",
     "@angular/compiler-cli": "4.0.0",
     "@angular/forms": "4.0.0",
@@ -24,13 +27,7 @@
     "ionicons": "3.0.0",
     "rxjs": "5.1.1",
     "sw-toolbox": "3.4.0",
-    "zone.js": "^0.8.4"
-  },
-  "peerDepedencies": {
-    "@angular/common": "^4.0.0",
-    "@angular/core": "^4.0.0"
-  },
-  "devDependencies": {
+    "zone.js": "^0.8.4",
     "typescript": "~2.2.1"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -10,10 +10,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "@angular/common": "4.0.0",
     "@angular/compiler": "4.0.0",
     "@angular/compiler-cli": "4.0.0",
-    "@angular/core": "4.0.0",
     "@angular/forms": "4.0.0",
     "@angular/http": "4.0.0",
     "@angular/platform-browser": "4.0.0",
@@ -27,6 +25,10 @@
     "rxjs": "5.1.1",
     "sw-toolbox": "3.4.0",
     "zone.js": "^0.8.4"
+  },
+  "peerDepedencies": {
+    "@angular/common": "^4.0.0",
+    "@angular/core": "^4.0.0"
   },
   "devDependencies": {
     "typescript": "~2.2.1"


### PR DESCRIPTION
Some of the angular dependencies need to be peer dependencies for AOT to work.  Here's a description: https://medium.com/@isaacplmann/making-your-angular-2-library-statically-analyzable-for-aot-e1c6f3ebedd5

I believe this should fix issue #121.

It might also be nice to be less strict in the rest of the dependencies (e.g., use `"@angular/http": "^4.0.0"` instead of the strict only 4.0.0 used right now).  Let me know if that sounds like a good idea and I can do another pull request.