### PR TITLE
Reset isFinished flags to false to ensure onFinish emit fires more than once

### DIFF
--- a/src/ionic-audio-track-component.ts
+++ b/src/ionic-audio-track-component.ts
@@ -1,18 +1,18 @@
-import {ITrackConstraint, IAudioTrack} from './ionic-audio-interfaces'; 
-import {AudioProvider} from './ionic-audio-providers'; 
-import {WebAudioTrack} from './ionic-audio-web-track'; 
-import {CordovaAudioTrack} from './ionic-audio-cordova-track'; 
+import {ITrackConstraint, IAudioTrack} from './ionic-audio-interfaces';
+import {AudioProvider} from './ionic-audio-providers';
+import {WebAudioTrack} from './ionic-audio-web-track';
+import {CordovaAudioTrack} from './ionic-audio-cordova-track';
 
 import {Component, DoCheck, EventEmitter, Output, Input} from '@angular/core';
 
 
 /**
- * # ```<audio-track>``` 
- * 
+ * # ```<audio-track>```
+ *
  * Creates a top level audio-track component
- * 
+ *
  * ## Usage
- * 
+ *
  * ````
  *   <audio-track #audio [track]="myTrack" (onFinish)="onTrackFinished($event)">
  *   ...
@@ -26,7 +26,7 @@ import {Component, DoCheck, EventEmitter, Output, Input} from '@angular/core';
     selector: 'audio-track',
     template: '<ng-content></ng-content>'
 })
-export class AudioTrackComponent implements DoCheck { 
+export class AudioTrackComponent implements DoCheck {
   /**
    * Input property containing a JSON object with at least a src property
    * ````
@@ -42,113 +42,115 @@ export class AudioTrackComponent implements DoCheck {
    * @type {ITrackConstraint}
    */
   @Input() track: ITrackConstraint;
-  
+
   /**
    * Output property expects an event handler to be notified whenever playback finishes
-   * 
+   *
    * @property onFinish
    * @type {EventEmitter}
    */
   @Output() onFinish = new EventEmitter<ITrackConstraint>();
-  
+
   private _isFinished: boolean = false;
   private _audioTrack: IAudioTrack;
-  
+
   constructor(private _audioProvider: AudioProvider) {}
-  
+
   ngOnInit() {
     if (!(this.track instanceof WebAudioTrack) && !(this.track instanceof CordovaAudioTrack)) {
-      this._audioTrack = this._audioProvider.create(this.track); 
+      this._audioTrack = this._audioProvider.create(this.track);
     } else {
       Object.assign(this._audioTrack, this.track);
       this._audioProvider.add(this._audioTrack);
     }
-    
+
     // update input track parameter with track is so we pass it to WebAudioProvider if needed
-    this.track.id = this._audioTrack.id; 
+    this.track.id = this._audioTrack.id;
   }
-  
-  play() {    
+
+  play() {
     this._audioTrack.play();
     this._audioProvider.current = this._audioTrack.id;
   }
-  
+
   pause() {
     this._audioTrack.pause();
     this._audioProvider.current = undefined;
   }
-  
+
   toggle() {
     if (this._audioTrack.isPlaying) {
       this.pause();
     } else {
       this.play();
-    }  
+    }
   }
-  
+
   seekTo(time:number) {
-    this._audioTrack.seekTo(time);  
+    this._audioTrack.seekTo(time);
   }
-  
-  
+
+
   public get id() : number {
     return this._audioTrack.id;
   }
-  
+
   public get art() : string {
     return this.track.art;
   }
-  
-  
+
+
   public get artist() : string {
     return this.track.artist;
   }
-  
-  
+
+
   public get title() : string {
     return this.track.title;
   }
-    
+
   public get progress() : number {
     return this._audioTrack.progress;
   }
-      
+
   public get isPlaying() : boolean {
     return this._audioTrack.isPlaying;
   }
-  
+
   public get duration() : number {
     return this._audioTrack.duration;
   }
-  
+
   public get completed() : number {
     return this._audioTrack.completed;
   }
-  
+
   public get canPlay() {
     return this._audioTrack.canPlay;
   }
-  
+
   public get error() {
     return this._audioTrack.error;
   }
-  
+
   public get isLoading() : boolean {
     return this._audioTrack.isLoading;
   }
-  
+
   public get hasLoaded() : boolean {
     return this.hasLoaded;
   }
-  
+
   ngDoCheck() {
     if(!Object.is(this._audioTrack.isFinished, this._isFinished)) {
       // some logic here to react to the change
       this._isFinished = this._audioTrack.isFinished;
-      
+
       // track has stopped, trigger finish event
       if (this._isFinished) {
-        this.onFinish.emit(this.track);       
+        this.onFinish.emit(this.track);
+        this._isFinished = false;
+        this._audioTrack.isFinished = false;
       }
     }
   }


### PR DESCRIPTION
Hi @arielfaur, I found that when a track was played to completion a second time after the component loaded, that the `onFinish` emit event never fired.  

This PR resets the`_isFinished` and `_audioTrack.isFinished` to `false` allowed the event to execute each time without a component reload.