### PR TITLE
Using map-get() breaks app, using color() is identical but does not break the app.

### DIFF
--- a/src/ionic-audio.scss
+++ b/src/ionic-audio.scss
@@ -57,13 +57,13 @@ audio-track {
           margin: 0 !important;
           
           &.light {
-            background: map-get($colors, dark);
-            color: map-get($colors, light);
+            background: color($colors, dark);
+            color: color($colors, light);
             opacity: .8;
           }
           
           &.dark {
-            color: map-get($colors, dark);
+            color: color($colors, dark);
             opacity: .6;
           }
           


### PR DESCRIPTION
Using map-get causes issues with Ionic, using `color()` works exactly the same.